### PR TITLE
Fix transition for popped screen with custom transition

### DIFF
--- a/guia/src/main/java/com/roudikk/guia/core/Navigator.kt
+++ b/guia/src/main/java/com/roudikk/guia/core/Navigator.kt
@@ -188,9 +188,12 @@ private fun Navigator.getTransition(
         // If the current transition is being overridden, then we use that transition.
         overrideTransition != null -> overrideTransition
 
-        backstack.isNotEmpty() ->
+        backstack.isNotEmpty() -> {
+            val entryClass =
+                if (isPop) previousEntry.navigationKey::class else newEntry.navigationKey::class
+
             // First we check if there's a transition defined for a certain key.
-            navigatorConfig.keyTransitions[newEntry.navigationKey::class]
+            navigatorConfig.keyTransitions[entryClass]
                 ?.invoke(previousEntry.navigationKey, newEntry.navigationKey, isPop)
 
             // If a key transition doesn't exist, we check for a node transition.
@@ -203,6 +206,7 @@ private fun Navigator.getTransition(
                     newEntry.navigationKey,
                     isPop
                 )
+        }
 
         // Otherwise we don't show any transition.
         else -> EnterExitTransition.None

--- a/guia/src/test/java/com/roudikk/guia/NavigatorTest.kt
+++ b/guia/src/test/java/com/roudikk/guia/NavigatorTest.kt
@@ -115,8 +115,8 @@ class NavigatorTest {
         assertThat(navigator.keyTransition<Screen>().exit).isEqualTo(testKeyTransition.enterExit.exit)
 
         navigator.setBackstack(navigator.backstack.dropLast(1))
-        assertThat(navigator.keyTransition<Screen>().enter).isEqualTo(navigationKeyTransition.popEnterExit.enter)
-        assertThat(navigator.keyTransition<Screen>().exit).isEqualTo(navigationKeyTransition.popEnterExit.exit)
+        assertThat(navigator.keyTransition<Screen>().enter).isEqualTo(testKeyTransition.popEnterExit.enter)
+        assertThat(navigator.keyTransition<Screen>().exit).isEqualTo(testKeyTransition.popEnterExit.exit)
 
         navigator.setBackstack(navigator.backstack + testKey2.entry())
         assertThat(navigator.keyTransition<Screen>().enter).isEqualTo(EnterTransition.None)

--- a/sample/feature-details/navigation/src/main/java/com/roudikk/guia/sample/feature/details/navigation/DetailsNavigation.kt
+++ b/sample/feature-details/navigation/src/main/java/com/roudikk/guia/sample/feature/details/navigation/DetailsNavigation.kt
@@ -10,3 +10,6 @@ value class DetailsResult(val value: String) : Parcelable
 
 @Parcelize
 class DetailsKey(val item: String) : NavigationKey
+
+@Parcelize
+class DetailsCustomTransitionKey(val item: String) : NavigationKey

--- a/sample/feature-details/src/main/java/com/roudikk/guia/sample/feature/details/DetailsEventEffect.kt
+++ b/sample/feature-details/src/main/java/com/roudikk/guia/sample/feature/details/DetailsEventEffect.kt
@@ -14,6 +14,7 @@ import com.roudikk.guia.extensions.setResult
 import com.roudikk.guia.extensions.singleInstance
 import com.roudikk.guia.extensions.singleTop
 import com.roudikk.guia.sample.feature.common.navigation.CrossFadeTransition
+import com.roudikk.guia.sample.feature.details.navigation.DetailsCustomTransitionKey
 import com.roudikk.guia.sample.feature.details.navigation.DetailsKey
 import com.roudikk.guia.sample.feature.details.navigation.DetailsResult
 import com.roudikk.guia.sample.feature.dialogs.navigation.BlockingBottomSheetKey
@@ -76,6 +77,10 @@ fun DetailsEventEffect(
             is DetailsEvent.OverrideScreenTransition -> {
                 navigator.overrideTransition<Screen>(CrossFadeTransition.enterExit)
                 navigator.push(DetailsKey(event.item))
+            }
+
+            is DetailsEvent.CustomScreenTransition -> {
+                navigator.push(DetailsCustomTransitionKey(event.item))
             }
 
             is DetailsEvent.SendResult -> {

--- a/sample/feature-details/src/main/java/com/roudikk/guia/sample/feature/details/DetailsList.kt
+++ b/sample/feature-details/src/main/java/com/roudikk/guia/sample/feature/details/DetailsList.kt
@@ -47,7 +47,8 @@ fun DetailsList(
     onReplaceSelected: () -> Unit = {},
     onOpenDialogSelected: () -> Unit = {},
     onOpenBlockingBottomSheet: () -> Unit = {},
-    onOverrideScreenTransitionSelected: () -> Unit = {}
+    onOverrideScreenTransitionSelected: () -> Unit = {},
+    onCustomScreenTransitionSelected: () -> Unit = {},
 ) {
     Column(
         modifier = Modifier
@@ -127,6 +128,11 @@ fun DetailsList(
         DetailsAction(
             title = "Override screen transition",
             onClick = onOverrideScreenTransitionSelected
+        )
+
+        DetailsAction(
+            title = "Custom screen transition",
+            onClick = onCustomScreenTransitionSelected
         )
 
         DetailsAction(

--- a/sample/feature-details/src/main/java/com/roudikk/guia/sample/feature/details/DetailsNavigationBuilder.kt
+++ b/sample/feature-details/src/main/java/com/roudikk/guia/sample/feature/details/DetailsNavigationBuilder.kt
@@ -13,6 +13,8 @@ import com.roudikk.guia.extensions.localBottomSheet
 import com.roudikk.guia.extensions.pop
 import com.roudikk.guia.extensions.requireLocalNavigator
 import com.roudikk.guia.sample.feature.common.navigation.CrossFadeTransition
+import com.roudikk.guia.sample.feature.common.navigation.VerticalSlideTransition
+import com.roudikk.guia.sample.feature.details.navigation.DetailsCustomTransitionKey
 import com.roudikk.guia.sample.feature.details.navigation.DetailsKey
 import kotlinx.parcelize.Parcelize
 
@@ -78,6 +80,8 @@ fun NavigatorConfigBuilder.detailsNavigation(screenWidth: Int) {
     }
 
     screen<DetailsKey> { DetailsScaffold(item = it.item) }
+    screen<DetailsCustomTransitionKey> { DetailsScaffold(item = it.item) }
 
     keyTransition<DynamicDetailsKey> { -> CrossFadeTransition }
+    keyTransition<DetailsCustomTransitionKey> { -> VerticalSlideTransition }
 }

--- a/sample/feature-details/src/main/java/com/roudikk/guia/sample/feature/details/DetailsScreen.kt
+++ b/sample/feature-details/src/main/java/com/roudikk/guia/sample/feature/details/DetailsScreen.kt
@@ -80,6 +80,7 @@ internal fun DetailsContent(
         onReplaceSelected = viewModel::onReplaceSelected,
         onOpenDialogSelected = viewModel::onOpenDialogSelected,
         onOpenBlockingBottomSheet = viewModel::onOpenBlockingBottomSheet,
-        onOverrideScreenTransitionSelected = viewModel::onOverrideScreenTransitionSelected
+        onOverrideScreenTransitionSelected = viewModel::onOverrideScreenTransitionSelected,
+        onCustomScreenTransitionSelected = viewModel::onCustomScreenTransitionSelected,
     )
 }

--- a/sample/feature-details/src/main/java/com/roudikk/guia/sample/feature/details/DetailsViewModel.kt
+++ b/sample/feature-details/src/main/java/com/roudikk/guia/sample/feature/details/DetailsViewModel.kt
@@ -20,6 +20,7 @@ sealed class DetailsEvent {
     data class OpenReplaced(val item: String) : DetailsEvent()
     data class OpenDialog(val item: String) : DetailsEvent()
     data class OverrideScreenTransition(val item: String) : DetailsEvent()
+    data class CustomScreenTransition(val item: String) : DetailsEvent()
 }
 
 class DetailsViewModel(
@@ -81,6 +82,10 @@ class DetailsViewModel(
 
     fun onOverrideScreenTransitionSelected() {
         event = DetailsEvent.OverrideScreenTransition(newItem())
+    }
+
+    fun onCustomScreenTransitionSelected() {
+        event = DetailsEvent.CustomScreenTransition(newItem())
     }
 
     fun onEventHandled() {


### PR DESCRIPTION
## Description

If using custom transition with `keyTransition`, then returning to previous screen occurred with wrong animation.

For example, there is screen A, B, C. Screens A and C open with a default transition. Screen B with a custom transition.
Open screens A -> B -> C. In this case all screens will display with a correct transition.
Now, if you go back to screen B, the transition from C to B will be with a custom animation, while it should be with a default transition, because screen C opened with default. 

For example, I added `DetailsCustomTransitionKey` with `VerticalSlideTransition`.

<details>
<summary>Screen record</summary>

https://user-images.githubusercontent.com/7170090/218724694-14022ed8-e6df-46b2-844e-ae95c4830850.mp4

</details>

## Solution

Fixed function `Navigator.getTransition`.
If there is a pop to previous screen, then take the transition for `previousEntry`.

<details>
<summary>Screen record</summary>

https://user-images.githubusercontent.com/7170090/218726074-c175c823-2114-4587-9530-6c0875faf203.mp4

</details>

