### PR TITLE
Update CompositionLocal navigation providers

### DIFF
--- a/guia/src/main/java/com/roudikk/guia/containers/NavContainer.kt
+++ b/guia/src/main/java/com/roudikk/guia/containers/NavContainer.kt
@@ -16,7 +16,6 @@ import com.roudikk.guia.core.Screen
 import com.roudikk.guia.extensions.LocalNavigator
 import com.roudikk.guia.extensions.LocalParentNavigator
 import com.roudikk.guia.extensions.canGoBack
-import com.roudikk.guia.extensions.localNavigator
 import com.roudikk.guia.extensions.pop
 import com.roudikk.guia.lifecycle.rememberDefaultLifecycleManager
 
@@ -42,7 +41,7 @@ fun Navigator.NavContainer(
     bottomSheetContainer: Container = { content -> content() },
     dialogContainer: Container = { content -> content() }
 ) {
-    val parentNavigator = localNavigator()
+    val parentNavigator = LocalNavigator.current
 
     CompositionLocalProvider(
         LocalParentNavigator provides parentNavigator,

--- a/guia/src/main/java/com/roudikk/guia/extensions/LocalNavHost.kt
+++ b/guia/src/main/java/com/roudikk/guia/extensions/LocalNavHost.kt
@@ -1,6 +1,8 @@
 package com.roudikk.guia.extensions
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.staticCompositionLocalOf
 import com.roudikk.guia.containers.NavContainer
 import com.roudikk.guia.navhost.NavHost
@@ -9,11 +11,30 @@ import com.roudikk.guia.navhost.NavHost
  * For navigation keys hosted within a [NavHost] that require access to that nav host,
  * a Local is provided to all Composables inside a [NavHost.NavContainer].
  */
-internal val LocalNavHost = staticCompositionLocalOf<NavHost?> { error("Must be provided") }
+val LocalNavHost = staticCompositionLocalOf<NavHost?> { null }
+
+/**
+ * Returns a [NavHost] that is hosting the caller Composable.
+ *
+ * @throws IllegalStateException if the [LocalNavHost] was not provided.
+ */
+val ProvidableCompositionLocal<NavHost?>.currentOrThrow: NavHost
+    @ReadOnlyComposable
+    @Composable
+    inline get() = checkNotNull(current) {
+        "No NavHost found, Call LocalNavHost inside a NavigationKey hosted by a NavHost."
+    }
 
 /**
  * Returns an optional [NavHost] that is hosting the caller Composable.
  */
+@Deprecated(
+    "Use LocalNavHost.current",
+    replaceWith = ReplaceWith(
+        expression = "LocalNavHost.current",
+        imports = arrayOf("com.roudikk.guia.extensions.LocalNavHost")
+    )
+)
 @Composable
 fun localNavHost() = LocalNavHost.current
 
@@ -22,6 +43,16 @@ fun localNavHost() = LocalNavHost.current
  *
  * @throws IllegalStateException if the [LocalNavHost] was not provided.
  */
+@Deprecated(
+    "Use LocalNavHost.currentOrThrow",
+    replaceWith = ReplaceWith(
+        expression = "LocalNavHost.currentOrThrow",
+        imports = arrayOf(
+            "com.roudikk.guia.extensions.LocalNavHost",
+            "com.roudikk.guia.extensions.currentOrThrow",
+        )
+    )
+)
 @Composable
 fun requireLocalNavHost() = checkNotNull(LocalNavHost.current) {
     "No NavHost found, Call requireNavHost inside a NavigationKey hosted by a NavHost."

--- a/guia/src/main/java/com/roudikk/guia/extensions/LocalNavigationNode.kt
+++ b/guia/src/main/java/com/roudikk/guia/extensions/LocalNavigationNode.kt
@@ -1,22 +1,42 @@
 package com.roudikk.guia.extensions
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.compositionLocalOf
 import com.roudikk.guia.core.BottomSheet
 import com.roudikk.guia.core.Dialog
 import com.roudikk.guia.core.NavigationNode
+import com.roudikk.guia.core.Navigator
 import com.roudikk.guia.core.Screen
 
 /**
  * The local navigation node that is hosting a certain composable.
  */
-internal val LocalNavigationNode = compositionLocalOf<NavigationNode?> {
-    error("Must be called inside a Composable hosted in a navigation node.")
-}
+val LocalNavigationNode = compositionLocalOf<NavigationNode?> { null }
+
+/**
+ * Returns the current local [NavigationNode].
+ *
+ * @throws IllegalStateException if called inside a Composable not hosted by a [NavigationNode]
+ */
+val ProvidableCompositionLocal<NavigationNode?>.currentOrThrow: NavigationNode
+    @ReadOnlyComposable
+    @Composable
+    inline get() = checkNotNull(current) {
+        "LocalNavigationNode must be called inside a Composable hosted in a navigation node."
+    }
 
 /**
  * Returns the current local [NavigationNode] if one is available.
  */
+@Deprecated(
+    "Use LocalNavigationNode.current",
+    replaceWith = ReplaceWith(
+        expression = "LocalNavigationNode.current",
+        imports = arrayOf("com.roudikk.guia.extensions.LocalNavigationNode")
+    )
+)
 @Composable
 fun localNavigationNode(): NavigationNode? = LocalNavigationNode.current
 
@@ -25,6 +45,16 @@ fun localNavigationNode(): NavigationNode? = LocalNavigationNode.current
  *
  * @throws IllegalStateException if called inside a Composable not hosted by a [NavigationNode]
  */
+@Deprecated(
+    "Use LocalNavigationNode.currentOrThrow",
+    replaceWith = ReplaceWith(
+        expression = "LocalNavigationNode.currentOrThrow",
+        imports = arrayOf(
+            "com.roudikk.guia.extensions.LocalNavigationNode",
+            "com.roudikk.guia.extensions.currentOrThrow",
+        )
+    )
+)
 @Composable
 fun requireLocalNavigationNode(): NavigationNode {
     return checkNotNull(LocalNavigationNode.current) {
@@ -35,6 +65,36 @@ fun requireLocalNavigationNode(): NavigationNode {
 /**
  * Returns the current local [BottomSheet] if one is available.
  */
+val ProvidableCompositionLocal<NavigationNode?>.currentAsBottomSheet: BottomSheet?
+    @ReadOnlyComposable
+    @Composable
+    inline get() = current as? BottomSheet
+
+/**
+ * Returns the current local [BottomSheet].
+ *
+ * @throws IllegalStateException if the navigation node is not a bottom sheet.
+ */
+val ProvidableCompositionLocal<NavigationNode?>.currentAsBottomSheetOrThrow: BottomSheet
+    @ReadOnlyComposable
+    @Composable
+    inline get() = checkNotNull(currentAsBottomSheet) {
+        "Must be called in a Composable hosted in a BottomSheet"
+    }
+
+/**
+ * Returns the current local [BottomSheet] if one is available.
+ */
+@Deprecated(
+    "Use LocalNavigationNode.currentAsBottomSheet",
+    replaceWith = ReplaceWith(
+        expression = "LocalNavigationNode.currentAsBottomSheet",
+        imports = arrayOf(
+            "com.roudikk.guia.extensions.LocalNavigationNode",
+            "com.roudikk.guia.extensions.currentAsBottomSheet",
+        )
+    )
+)
 @Composable
 fun localBottomSheet() = localNavigationNode() as? BottomSheet
 
@@ -43,6 +103,16 @@ fun localBottomSheet() = localNavigationNode() as? BottomSheet
  *
  * @throws IllegalStateException if the navigation node is not a bottom sheet.
  */
+@Deprecated(
+    "Use LocalNavigationNode.currentAsBottomSheetOrThrow",
+    replaceWith = ReplaceWith(
+        expression = "LocalNavigationNode.currentAsBottomSheetOrThrow",
+        imports = arrayOf(
+            "com.roudikk.guia.extensions.LocalNavigationNode",
+            "com.roudikk.guia.extensions.currentAsBottomSheetOrThrow",
+        )
+    )
+)
 @Composable
 fun requireLocalBottomSheet() = checkNotNull(localBottomSheet()) {
     "Must be called in a Composable hosted in a BottomSheet"
@@ -51,6 +121,36 @@ fun requireLocalBottomSheet() = checkNotNull(localBottomSheet()) {
 /**
  * Returns the current local [Dialog] if one is available.
  */
+val ProvidableCompositionLocal<NavigationNode?>.currentAsDialog: Dialog?
+    @ReadOnlyComposable
+    @Composable
+    inline get() = current as? Dialog
+
+/**
+ * Returns the current local [Dialog].
+ *
+ * @throws IllegalStateException if the navigation node is not a dialog.
+ */
+val ProvidableCompositionLocal<NavigationNode?>.currentAsDialogOrThrow: Dialog
+    @ReadOnlyComposable
+    @Composable
+    inline get() = checkNotNull(currentAsDialog) {
+        "Must be called in a Composable hosted in a Dialog"
+    }
+
+/**
+ * Returns the current local [Dialog] if one is available.
+ */
+@Deprecated(
+    "Use LocalNavigationNode.currentAsDialog",
+    replaceWith = ReplaceWith(
+        expression = "LocalNavigationNode.currentAsDialog",
+        imports = arrayOf(
+            "com.roudikk.guia.extensions.LocalNavigationNode",
+            "com.roudikk.guia.extensions.currentAsDialog",
+        )
+    )
+)
 @Composable
 fun localDialog() = localNavigationNode() as? Dialog
 
@@ -59,6 +159,16 @@ fun localDialog() = localNavigationNode() as? Dialog
  *
  * @throws IllegalStateException if the navigation node is not a dialog.
  */
+@Deprecated(
+    "Use LocalNavigationNode.currentAsDialogOrThrow",
+    replaceWith = ReplaceWith(
+        expression = "LocalNavigationNode.currentAsDialogOrThrow",
+        imports = arrayOf(
+            "com.roudikk.guia.extensions.LocalNavigationNode",
+            "com.roudikk.guia.extensions.currentAsDialogOrThrow",
+        )
+    )
+)
 @Composable
 fun requireLocalDialog() = checkNotNull(localDialog()) {
     "Must be called in a Composable hosted in a Dialog"
@@ -67,6 +177,37 @@ fun requireLocalDialog() = checkNotNull(localDialog()) {
 /**
  * Returns the current local [Screen] if one is available.
  */
+val ProvidableCompositionLocal<NavigationNode?>.currentAsScreen: Screen?
+    @ReadOnlyComposable
+    @Composable
+    inline get() = current as? Screen
+
+/**
+ * Returns the current local [Screen].
+ *
+ * @throws IllegalStateException if the navigation node is not a screen.
+ */
+val ProvidableCompositionLocal<NavigationNode?>.currentAsScreenOrThrow: Screen
+    @ReadOnlyComposable
+    @Composable
+    inline get() = checkNotNull(currentAsScreen) {
+        "Must be called in a Composable hosted in a screen"
+    }
+
+
+/**
+ * Returns the current local [Screen] if one is available.
+ */
+@Deprecated(
+    "Use LocalNavigationNode.currentAsScreen",
+    replaceWith = ReplaceWith(
+        expression = "LocalNavigationNode.currentAsScreen",
+        imports = arrayOf(
+            "com.roudikk.guia.extensions.LocalNavigationNode",
+            "com.roudikk.guia.extensions.currentAsScreen",
+        )
+    )
+)
 @Composable
 fun localScreen() = localNavigationNode() as? Screen
 
@@ -75,6 +216,16 @@ fun localScreen() = localNavigationNode() as? Screen
  *
  * @throws IllegalStateException if the navigation node is not a screen.
  */
+@Deprecated(
+    "Use LocalNavigationNode.currentAsScreenOrThrow",
+    replaceWith = ReplaceWith(
+        expression = "LocalNavigationNode.currentAsScreenOrThrow",
+        imports = arrayOf(
+            "com.roudikk.guia.extensions.LocalNavigationNode",
+            "com.roudikk.guia.extensions.currentAsScreenOrThrow",
+        )
+    )
+)
 @Composable
 fun requireLocalScreen() = checkNotNull(localScreen()) {
     "Must be called in a Composable hosted in a screen"

--- a/guia/src/main/java/com/roudikk/guia/extensions/LocalNavigator.kt
+++ b/guia/src/main/java/com/roudikk/guia/extensions/LocalNavigator.kt
@@ -1,6 +1,8 @@
 package com.roudikk.guia.extensions
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.compositionLocalOf
 import com.roudikk.guia.containers.NavContainer
 import com.roudikk.guia.core.Navigator
@@ -9,16 +11,35 @@ import com.roudikk.guia.core.Navigator
  * Provides access to the current navigator, accessible to all composables
  * within the context of a [NavContainer].
  */
-internal val LocalNavigator = compositionLocalOf<Navigator?> { null }
+val LocalNavigator = compositionLocalOf<Navigator?> { null }
 
 /**
  * Provides access to the current parent navigator, if one exists.
  */
-internal val LocalParentNavigator = compositionLocalOf<Navigator?> { null }
+val LocalParentNavigator = compositionLocalOf<Navigator?> { null }
+
+/**
+ * Returns an [Navigator] that is hosting the caller Composable.
+ *
+ * @throws IllegalStateException if it's called in Composable not within a [NavContainer]
+ */
+val ProvidableCompositionLocal<Navigator?>.currentOrThrow: Navigator
+    @ReadOnlyComposable
+    @Composable
+    inline get() = checkNotNull(current) {
+        "LocalNavigator must be called in a NavigationNode hosted in a NavContainer."
+    }
 
 /**
  * Returns an optional [Navigator] that is hosting the caller Composable.
  */
+@Deprecated(
+    "Use LocalNavigator.current",
+    replaceWith = ReplaceWith(
+        expression = "LocalNavigator.current",
+        imports = arrayOf("com.roudikk.guia.extensions.LocalNavigator")
+    )
+)
 @Composable
 fun localNavigator(): Navigator? {
     return LocalNavigator.current
@@ -29,6 +50,16 @@ fun localNavigator(): Navigator? {
  *
  * @throws IllegalStateException if it's called in Composable not within a [NavContainer]
  */
+@Deprecated(
+    "Use LocalNavigator.currentOrThrow",
+    replaceWith = ReplaceWith(
+        expression = "LocalNavigator.currentOrThrow",
+        imports = arrayOf(
+            "com.roudikk.guia.extensions.LocalNavigator",
+            "com.roudikk.guia.extensions.currentOrThrow",
+        )
+    )
+)
 @Composable
 fun requireLocalNavigator(): Navigator {
     return checkNotNull(LocalNavigator.current) {
@@ -40,6 +71,13 @@ fun requireLocalNavigator(): Navigator {
  * Returns an optional [Navigator] that is the parent of the current navigator hosting
  * the caller Composable.
  */
+@Deprecated(
+    "Use LocalParentNavigator.current",
+    replaceWith = ReplaceWith(
+        expression = "LocalParentNavigator.current",
+        imports = arrayOf("com.roudikk.guia.extensions.LocalParentNavigator")
+    )
+)
 @Composable
 fun localParentNavigator(): Navigator? {
     return LocalParentNavigator.current
@@ -51,6 +89,16 @@ fun localParentNavigator(): Navigator? {
  *
  * @throws IllegalStateException if there is no parent [Navigator] in the current context.
  */
+@Deprecated(
+    "Use LocalParentNavigator.currentOrThrow",
+    replaceWith = ReplaceWith(
+        expression = "LocalParentNavigator.currentOrThrow",
+        imports = arrayOf(
+            "com.roudikk.guia.extensions.LocalParentNavigator",
+            "com.roudikk.guia.extensions.currentOrThrow",
+        )
+    )
+)
 @Composable
 fun requireLocalParentNavigator(): Navigator {
     return checkNotNull(LocalParentNavigator.current)

--- a/sample/feature-common/src/main/java/com/roudikk/guia/sample/feature/common/navigation/NavigationExtensions.kt
+++ b/sample/feature-common/src/main/java/com/roudikk/guia/sample/feature/common/navigation/NavigationExtensions.kt
@@ -1,16 +1,10 @@
 package com.roudikk.guia.sample.feature.common.navigation
 
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.lifecycle.ViewModelStoreOwner
 import com.roudikk.guia.core.Navigator
 
 val LocalRootNavigator = staticCompositionLocalOf<Navigator> { error("Must be provided.") }
-
-@Composable
-fun requireRootNavigator(): Navigator {
-    return requireNotNull(LocalRootNavigator.current)
-}
 
 val LocalNavHostViewModelStoreOwner = staticCompositionLocalOf<ViewModelStoreOwner> {
     error("Must be provided")

--- a/sample/feature-details/src/main/java/com/roudikk/guia/sample/feature/details/DetailsEventEffect.kt
+++ b/sample/feature-details/src/main/java/com/roudikk/guia/sample/feature/details/DetailsEventEffect.kt
@@ -4,12 +4,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import com.roudikk.guia.core.Screen
 import com.roudikk.guia.core.overrideTransition
-import com.roudikk.guia.extensions.push
+import com.roudikk.guia.extensions.LocalNavigator
+import com.roudikk.guia.extensions.LocalParentNavigator
+import com.roudikk.guia.extensions.currentOrThrow
 import com.roudikk.guia.extensions.pop
 import com.roudikk.guia.extensions.popToRoot
+import com.roudikk.guia.extensions.push
 import com.roudikk.guia.extensions.replaceLast
-import com.roudikk.guia.extensions.requireLocalNavigator
-import com.roudikk.guia.extensions.requireLocalParentNavigator
 import com.roudikk.guia.extensions.setResult
 import com.roudikk.guia.extensions.singleInstance
 import com.roudikk.guia.extensions.singleTop
@@ -24,8 +25,8 @@ import com.roudikk.guia.sample.feature.dialogs.navigation.BlockingBottomSheetKey
 fun DetailsEventEffect(
     viewModel: DetailsViewModel
 ) {
-    val navigator = requireLocalNavigator()
-    val parentNavigator = requireLocalParentNavigator()
+    val navigator = LocalNavigator.currentOrThrow
+    val parentNavigator = LocalParentNavigator.currentOrThrow
     val event = viewModel.event
 
     LaunchedEffect(event) {

--- a/sample/feature-details/src/main/java/com/roudikk/guia/sample/feature/details/DetailsNavigationBuilder.kt
+++ b/sample/feature-details/src/main/java/com/roudikk/guia/sample/feature/details/DetailsNavigationBuilder.kt
@@ -9,9 +9,11 @@ import com.roudikk.guia.core.BottomSheet
 import com.roudikk.guia.core.Dialog
 import com.roudikk.guia.core.NavigationKey
 import com.roudikk.guia.core.NavigatorConfigBuilder
-import com.roudikk.guia.extensions.localBottomSheet
+import com.roudikk.guia.extensions.LocalNavigationNode
+import com.roudikk.guia.extensions.LocalNavigator
+import com.roudikk.guia.extensions.currentAsBottomSheet
+import com.roudikk.guia.extensions.currentOrThrow
 import com.roudikk.guia.extensions.pop
-import com.roudikk.guia.extensions.requireLocalNavigator
 import com.roudikk.guia.sample.feature.common.navigation.CrossFadeTransition
 import com.roudikk.guia.sample.feature.common.navigation.VerticalSlideTransition
 import com.roudikk.guia.sample.feature.details.navigation.DetailsCustomTransitionKey
@@ -42,8 +44,8 @@ private val colorSaver = Saver<Color, List<Float>>(
 @Parcelize
 class DetailsBottomSheetKey(val item: String) : NavigationKey.WithNode<BottomSheet> {
     override fun navigationNode() = BottomSheet {
-        val navigator = requireLocalNavigator()
-        val bottomSheet = localBottomSheet()
+        val navigator = LocalNavigator.currentOrThrow
+        val bottomSheet = LocalNavigationNode.currentAsBottomSheet
         val scrimColor = rememberSaveable(key = "color", saver = colorSaver) {
             Color(
                 red = (0..255).random(),

--- a/sample/feature-dialogs/src/main/java/com/roudikk/guia/sample/feature/dialogs/BlockingBottomSheet.kt
+++ b/sample/feature-dialogs/src/main/java/com/roudikk/guia/sample/feature/dialogs/BlockingBottomSheet.kt
@@ -21,13 +21,14 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.roudikk.guia.backstack.NavBackHandler
 import com.roudikk.guia.core.BottomSheet
-import com.roudikk.guia.extensions.localBottomSheet
+import com.roudikk.guia.extensions.LocalNavigationNode
+import com.roudikk.guia.extensions.currentAsBottomSheet
 import com.roudikk.guia.sample.feature.common.composables.SampleSurfaceContainer
 import com.roudikk.guia.sample.feature.common.theme.AppTheme
 
 @Composable
 internal fun BlockingBottomSheetScreen() {
-    val bottomSheet = localBottomSheet()
+    val bottomSheet = LocalNavigationNode.currentAsBottomSheet
     var lockStateChange by rememberSaveable { mutableStateOf(true) }
 
     LaunchedEffect(lockStateChange) {

--- a/sample/feature-dialogs/src/main/java/com/roudikk/guia/sample/feature/dialogs/BlockingDialog.kt
+++ b/sample/feature-dialogs/src/main/java/com/roudikk/guia/sample/feature/dialogs/BlockingDialog.kt
@@ -22,10 +22,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.roudikk.guia.extensions.localDialog
-import com.roudikk.guia.extensions.push
+import com.roudikk.guia.extensions.LocalNavigationNode
+import com.roudikk.guia.extensions.LocalNavigator
+import com.roudikk.guia.extensions.currentAsDialog
+import com.roudikk.guia.extensions.currentOrThrow
 import com.roudikk.guia.extensions.pop
-import com.roudikk.guia.extensions.requireLocalNavigator
+import com.roudikk.guia.extensions.push
 import com.roudikk.guia.sample.feature.common.theme.AppTheme
 import com.roudikk.guia.sample.feature.dialogs.navigation.CancelableDialogKey
 
@@ -33,7 +35,7 @@ import com.roudikk.guia.sample.feature.dialogs.navigation.CancelableDialogKey
 internal fun BlockingDialogScreen(
     showNextButton: Boolean
 ) {
-    val navigator = requireLocalNavigator()
+    val navigator = LocalNavigator.currentOrThrow
 
     BlockingDialogContent(
         showNextButton = showNextButton,
@@ -48,7 +50,7 @@ private fun BlockingDialogContent(
     onNextClicked: () -> Unit = {},
     onCancelClicked: () -> Unit = {}
 ) {
-    val dialog = localDialog()
+    val dialog = LocalNavigationNode.currentAsDialog
     var dismissDialog by rememberSaveable { mutableStateOf(false) }
 
     LaunchedEffect(dismissDialog) {

--- a/sample/feature-dialogs/src/main/java/com/roudikk/guia/sample/feature/dialogs/CancelableDialog.kt
+++ b/sample/feature-dialogs/src/main/java/com/roudikk/guia/sample/feature/dialogs/CancelableDialog.kt
@@ -16,15 +16,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.roudikk.guia.extensions.LocalNavigator
+import com.roudikk.guia.extensions.currentOrThrow
 import com.roudikk.guia.extensions.popToRoot
-import com.roudikk.guia.extensions.requireLocalNavigator
 import com.roudikk.guia.sample.feature.common.theme.AppTheme
 
 @Composable
 internal fun CancelableDialogScreen(
     showNextButton: Boolean
 ) {
-    val navigator = requireLocalNavigator()
+    val navigator = LocalNavigator.currentOrThrow
     CancelableDialogContent(
         showNextButton = showNextButton,
         onBackToRootClicked = navigator::popToRoot

--- a/sample/feature-dialogs/src/main/java/com/roudikk/guia/sample/feature/dialogs/DialogsScreen.kt
+++ b/sample/feature-dialogs/src/main/java/com/roudikk/guia/sample/feature/dialogs/DialogsScreen.kt
@@ -21,9 +21,10 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.roudikk.guia.extensions.LocalNavigator
+import com.roudikk.guia.extensions.currentOrThrow
 import com.roudikk.guia.extensions.push
-import com.roudikk.guia.extensions.requireLocalNavigator
-import com.roudikk.guia.sample.feature.common.navigation.requireRootNavigator
+import com.roudikk.guia.sample.feature.common.navigation.LocalRootNavigator
 import com.roudikk.guia.sample.feature.common.theme.AppTheme
 import com.roudikk.guia.sample.feature.dialogs.navigation.BlockingBottomSheetKey
 import com.roudikk.guia.sample.feature.dialogs.navigation.BlockingDialogKey
@@ -31,8 +32,8 @@ import com.roudikk.guia.sample.feature.dialogs.navigation.CancelableDialogKey
 
 @Composable
 internal fun DialogsScreen() {
-    val navigator = requireLocalNavigator()
-    val rootNavigator = requireRootNavigator()
+    val navigator = LocalNavigator.currentOrThrow
+    val rootNavigator = LocalRootNavigator.current
 
     DialogsContent(
         onCancelableDialogClicked = { navigator.push(CancelableDialogKey(false)) },

--- a/sample/feature-home/src/main/java/com/roudikk/guia/sample/feature/home/HomeEventEffect.kt
+++ b/sample/feature-home/src/main/java/com/roudikk/guia/sample/feature/home/HomeEventEffect.kt
@@ -5,11 +5,12 @@ import android.widget.Toast
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.platform.LocalContext
+import com.roudikk.guia.extensions.LocalNavigator
 import com.roudikk.guia.extensions.clearResult
+import com.roudikk.guia.extensions.currentOrThrow
 import com.roudikk.guia.extensions.push
-import com.roudikk.guia.extensions.requireLocalNavigator
 import com.roudikk.guia.extensions.setResult
-import com.roudikk.guia.sample.feature.common.navigation.requireRootNavigator
+import com.roudikk.guia.sample.feature.common.navigation.LocalRootNavigator
 import com.roudikk.guia.sample.feature.details.navigation.DetailsKey
 import com.roudikk.guia.sample.feature.details.navigation.DetailsResult
 import com.roudikk.guia.sample.feature.settings.navigation.SettingsKey
@@ -18,8 +19,8 @@ import com.roudikk.guia.sample.feature.settings.navigation.SettingsKey
 fun HomeEventEffect(
     viewModel: HomeViewModel
 ) {
-    val navigator = requireLocalNavigator()
-    val rootNavigator = requireRootNavigator()
+    val navigator = LocalNavigator.currentOrThrow
+    val rootNavigator = LocalRootNavigator.current
     val context = LocalContext.current
     val event = viewModel.event
 

--- a/sample/feature-home/src/main/java/com/roudikk/guia/sample/feature/home/HomeScreen.kt
+++ b/sample/feature-home/src/main/java/com/roudikk/guia/sample/feature/home/HomeScreen.kt
@@ -50,7 +50,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.roudikk.guia.backstack.NavBackHandler
-import com.roudikk.guia.extensions.requireLocalNavigator
+import com.roudikk.guia.extensions.LocalNavigator
+import com.roudikk.guia.extensions.currentOrThrow
 import com.roudikk.guia.extensions.result
 import com.roudikk.guia.sample.feature.details.navigation.DetailsResult
 import kotlinx.coroutines.launch
@@ -58,7 +59,7 @@ import kotlinx.coroutines.launch
 @Composable
 internal fun HomeScreen() {
     val viewModel = viewModel<HomeViewModel>()
-    val navigator = requireLocalNavigator()
+    val navigator = LocalNavigator.currentOrThrow
 
     val result = navigator.result<DetailsResult>()
 

--- a/sample/feature-nested/src/main/java/com/roudikk/guia/sample/feature/nested/NestedScreen.kt
+++ b/sample/feature-nested/src/main/java/com/roudikk/guia/sample/feature/nested/NestedScreen.kt
@@ -26,10 +26,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.roudikk.guia.extensions.LocalNavigator
 import com.roudikk.guia.extensions.canGoBack
-import com.roudikk.guia.extensions.push
+import com.roudikk.guia.extensions.currentOrThrow
 import com.roudikk.guia.extensions.pop
-import com.roudikk.guia.extensions.requireLocalNavigator
+import com.roudikk.guia.extensions.push
 import com.roudikk.guia.sample.feature.common.theme.AppTheme
 import com.roudikk.guia.sample.feature.nested.navigation.NestedKey
 
@@ -37,7 +38,7 @@ import com.roudikk.guia.sample.feature.nested.navigation.NestedKey
 internal fun NestedScreen(
     count: Int
 ) {
-    val navigator = requireLocalNavigator()
+    val navigator = LocalNavigator.currentOrThrow
     val canGoBack by navigator.canGoBack()
 
     NestedContent(

--- a/sample/feature-settings/src/main/java/com/roudikk/guia/sample/feature/settings/SettingsScreen.kt
+++ b/sample/feature-settings/src/main/java/com/roudikk/guia/sample/feature/settings/SettingsScreen.kt
@@ -40,13 +40,14 @@ import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.roudikk.guia.animation.NavVisibilityScope
+import com.roudikk.guia.extensions.LocalNavigator
+import com.roudikk.guia.extensions.currentOrThrow
 import com.roudikk.guia.extensions.pop
-import com.roudikk.guia.extensions.requireLocalNavigator
 import com.roudikk.guia.sample.feature.common.theme.AppTheme
 
 @Composable
 internal fun SettingsScreen() {
-    val navigator = requireLocalNavigator()
+    val navigator = LocalNavigator.currentOrThrow
     SettingsContent(
         onCloseClicked = navigator::pop
     )

--- a/sample/feature-welcome/src/main/java/com/roudikk/guia/sample/feature/welcome/WelcomeScreen.kt
+++ b/sample/feature-welcome/src/main/java/com/roudikk/guia/sample/feature/welcome/WelcomeScreen.kt
@@ -26,8 +26,9 @@ import com.airbnb.lottie.compose.LottieConstants
 import com.airbnb.lottie.compose.animateLottieCompositionAsState
 import com.airbnb.lottie.compose.rememberLottieComposition
 import com.roudikk.guia.animation.NavVisibilityScope
+import com.roudikk.guia.extensions.LocalNavigator
+import com.roudikk.guia.extensions.currentOrThrow
 import com.roudikk.guia.extensions.push
-import com.roudikk.guia.extensions.requireLocalNavigator
 import com.roudikk.guia.extensions.setRoot
 import com.roudikk.guia.sample.feature.bottomnav.navigation.BottomNavKey
 import com.roudikk.guia.sample.feature.common.composables.NavigationAnimationPreview
@@ -35,7 +36,7 @@ import com.roudikk.guia.sample.feature.common.theme.AppTheme
 
 @Composable
 internal fun WelcomeScreen() {
-    val navigator = requireLocalNavigator()
+    val navigator = LocalNavigator.currentOrThrow
 
     WelcomeContent(
         onNavigateBottomNav = { navigator.push(BottomNavKey()) },


### PR DESCRIPTION
1. Navigation providers (`LocalNavigator`, `LocalParentNavigator`, `LocalNavHost`) have opened to allow creating a custom `NavContainer`s
2. Migration to familiar CompositionLocal format (`localNavigator()` -> `LocalNavigator.current`, `requireLocalNavigator()` -> `LocalNavigator.currentOrThrow`)